### PR TITLE
Handle "multi prompt"

### DIFF
--- a/plugin/editcommand.vim
+++ b/plugin/editcommand.vim
@@ -8,24 +8,23 @@ let g:editcommand_loaded = 1
 
 " default bash prompt is $ so use that as a default
 let g:editcommand_prompt = get(g:, 'editcommand_prompt', '$')
+let s:space_or_eol = '\( \|$\|\n\)'
 
 function! s:strip_prompt(command)
   " strip up to and including the first occurence of the prompt
   echom 'command: "' . a:command . '"'
-  let l:space_or_eol = '\( \|$\)'
-  let l:prompt_idx = match(a:command, g:editcommand_prompt . l:space_or_eol . '\zs')
+  let l:prompt_idx = match(a:command, g:editcommand_prompt . s:space_or_eol . '\zs')
   let l:part = strpart(a:command, l:prompt_idx)
   return strpart(a:command, l:prompt_idx)
 endfunction
 
 function! s:extract_command() abort
   " if a user has not entered a command then there will not be a space after the last prompt
-  let l:space_or_eol = '\( \|$\)'
 
   " starting at the last line search backwards through the file for a line containing the prompt
   let l:line_number = line('$')
   while l:line_number > 0
-    if match(getline(l:line_number), g:editcommand_prompt . l:space_or_eol) !=# -1
+    if match(getline(l:line_number), g:editcommand_prompt . s:space_or_eol) !=# -1
       let s:command = s:strip_prompt(join(getline(l:line_number, '$'), "\n"))
       return
     endif

--- a/plugin/editcommand.vim
+++ b/plugin/editcommand.vim
@@ -11,7 +11,10 @@ let g:editcommand_prompt = get(g:, 'editcommand_prompt', '$')
 
 function! s:strip_prompt(command)
   " strip up to and including the first occurence of the prompt
-  let l:prompt_idx = stridx(a:command, get(g:, 'editcommand_prompt')) + len(get(g:, 'editcommand_prompt')) + 1
+  echom 'command: "' . a:command . '"'
+  let l:space_or_eol = '\( \|$\)'
+  let l:prompt_idx = match(a:command, g:editcommand_prompt . l:space_or_eol . '\zs')
+  let l:part = strpart(a:command, l:prompt_idx)
   return strpart(a:command, l:prompt_idx)
 endfunction
 


### PR DESCRIPTION
In a git repository my prompt looks like this:

```
git:multi-prompt nvim-editcommand: ls
```

So I set this:

``` vim
let g:editcommand_prompt = ':'
```

But because I have a `:` in the git part of my prompt, the `strip_prompt` function doesn't work. I updated it in this PR to handle this case, but I ran into a problem. To show this, I first added a commit to add some logging. Here are some examples of those logs:

```
After first commit on `~:` (no command) in `:term`:
command: "~:^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
part: "^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"

After first commit on `~: ls` in `:term`:
command: "~: ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
part: "ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"

After first commit on `git:multi-prompt nvim-editcommand: ls` in `:term`:
command: "git:multi-prompt nvim-editcommand: ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
part: "ulti-prompt nvim-editcommand: ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
```

Please note the `^@` characters. Those are literal `<C-@>` and I have no idea where they are from, but they are the source of the problem.

Anyway, it mostly works, except in the git repository where the wrong part gets extracted. This is what I want to fix.

In the second commit I actually changed the `strip_prompt` function to search for the right `:` by looking for a `:` followed by space or eol (like you already do in `extract_command`. Here's what I got with the same commands then:

```
After second commit on `git:multi-prompt nvim-editcommand: ls` in `:term`:
command: "git:multi-prompt nvim-editcommand: ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
part: "ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"

After second commit on `~: ls` in `:term`:
command: "~: ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
part: "ls^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"

After second commit on `~:` (no command) in `:term`:
command: "~:^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
part: "~:^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@"
```

You see that it now works both in git and non-git repository directories as long as there is a command after the prompt. If there is no command, those pesky `^@` characters make the eol not match.

Could you see (by using the first commit only) if you have those `^@` characters as well? Do you have an idea where they might be coming from?

I could fix it by updating the regex to ignore those characters before eol, but it would be better if we could understand what's actually going on here.

Once this is resolved I can clean up the PR by removing the logging again.
